### PR TITLE
windows: fix loading plugins relying on ssl

### DIFF
--- a/build.py
+++ b/build.py
@@ -439,6 +439,8 @@ class BuildWin64(Build):
             for f in glob.glob(f"{self.gst_native}/{av}*.dll"):
                 run(f"{strip} -s {f}")
         for f in glob.glob(f"{self.gst_native}/lib*dll"):
+            if 'libssl' in f:
+                continue
             run(f"{strip} -s {f}")
 
     def _get_gst_install_dir(self):


### PR DESCRIPTION
Don't strip the libssl library since it corrupts it: Failed to load plugin 'lib\gstreamer-1.0\gstdtls.dll': Invalid access to memory location.